### PR TITLE
Refactor: General

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { TaskListPage } from '../pages/task-list/task-list';
 import { CommonProvider } from '../providers/common/common';
 import { AuthProvider } from '../providers/auth/auth';
 
-import { IPage } from './../interfaces/page';
+import { IPage } from '../interfaces/page';
 
 @Component({
   templateUrl: 'app.html'
@@ -23,12 +23,13 @@ export class MyApp {
 
   rootPage: any;
 
-  constructor(platform: Platform,
-      statusBar: StatusBar,
-      splashScreen: SplashScreen,
-      private commonProvider: CommonProvider,
-      private authProvider: AuthProvider
-    ) {
+  constructor(
+    platform: Platform,
+    statusBar: StatusBar,
+    splashScreen: SplashScreen,
+    private _commonProvider: CommonProvider,
+    private _authProvider: AuthProvider
+  ) {
     platform.ready().then(() => {
       // Okay, so the platform is ready and our plugins are available.
       // Here you can do any higher level native things you might need.
@@ -36,12 +37,12 @@ export class MyApp {
       splashScreen.hide();
     });
 
-    commonProvider.readAuthenticationData().then(
+    _commonProvider.readAuthenticationData().then(
       data => {
-        this.authProvider.refreshToken().subscribe(
+        this._authProvider.refreshToken().subscribe(
           data => {
-            this.commonProvider.setAuthenticationData(data);
-            this.rootPage = this.commonProvider.isAuthenticated ? HomePage : SignInPage;
+            this._commonProvider.setAuthenticationData(data);
+            this.rootPage = this._commonProvider.isAuthenticated ? HomePage : SignInPage;
           },
           error => {
             this.rootPage = SignInPage;
@@ -51,9 +52,9 @@ export class MyApp {
     );
   }
 
-  get pages() {
+  public get pages() {
     let pageList: Array<IPage>;
-    if (this.commonProvider.isAuthenticated) {
+    if (this._commonProvider.isAuthenticated) {
       pageList = [
         { title: 'Home', component: HomePage, icon: 'md-home' },
         { title: 'Events', component: EventListPage, icon: 'md-calendar' },
@@ -72,5 +73,5 @@ export class MyApp {
   public openPage(page) {
     this.nav.setRoot(page);
   }
-}
 
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,10 +1,7 @@
 <ion-menu [content]="content">
   <ion-content>
     <ion-list>
-      <ion-item menuClose
-        class="menu-item"
-        *ngFor="let page of pages"
-        (tap)="openPage(page.component)">
+      <ion-item menuClose class="menu-item" *ngFor="let page of pages" (tap)="openPage(page.component)">
 
         <ion-icon name="{{ page.icon }}"></ion-icon>
         {{ page.title }}
@@ -14,4 +11,5 @@
   </ion-content>
 </ion-menu>
 
-<ion-nav #content [root]="rootPage"></ion-nav>
+<ion-nav #content [root]="rootPage">
+</ion-nav>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { EventUpdatePage } from '../pages/event-update/event-update';
 import { NoteListPage } from '../pages/note-list/note-list';
 import { NoteDetailPage } from '../pages/note-detail/note-detail';
 import { NoteCreatePage } from '../pages/note-create/note-create';
-import { NoteUpdatePage } from './../pages/note-update/note-update';
+import { NoteUpdatePage } from '../pages/note-update/note-update';
 import { TaskListPage } from '../pages/task-list/task-list';
 import { TaskDetailPage } from '../pages/task-detail/task-detail';
 import { TaskCreatePage } from '../pages/task-create/task-create';

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -1,6 +1,7 @@
 import {JsonObject, JsonProperty} from 'json2typescript';
 
 import { Category } from './category';
+
 import { Priority, Status } from '../custom-types';
 
 @JsonObject

--- a/src/pages/event-create/event-create.html
+++ b/src/pages/event-create/event-create.html
@@ -40,11 +40,7 @@
 
       <ion-item>
         <ion-label floating>Start date</ion-label>
-        <ion-datetime
-          formControlName="startDate"
-          id="startDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="startDate" id="startDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -62,11 +58,7 @@
 
       <ion-item>
         <ion-label floating>End date</ion-label>
-        <ion-datetime
-          formControlName="endDate"
-          id="endDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="endDate" id="endDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -108,10 +100,8 @@
           {{ description.errors.remote }}
         </div>
       </div>
-
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <input type="text" class="test-calss-gegwegwegweg" id="tetetet-tettet" data-test="tgetwetwet" name="tetetette">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Create
       </button>
     </form>

--- a/src/pages/event-create/event-create.spec.ts
+++ b/src/pages/event-create/event-create.spec.ts
@@ -2,15 +2,15 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe } from '@angular/common';
 import { FormBuilder } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { EventCreatePage } from './event-create';
+
 import { CommonProvider } from '../../providers/common/common';
 import { EventsProvider } from '../../providers/events/events';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
 class NavControllerStub {}
-class NavParamsStup {}
 class CommonProviderStub {}
 class EventsProviderStub {}
 class CategoriesProviderStub {}
@@ -24,10 +24,9 @@ describe('Pages: EventCreatePage', () => {
     TestBed.configureTestingModule({
       declarations: [EventCreatePage],
       providers: [
-        FormBuilder,
         DatePipe,
+        FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
-        { provide: NavParams, useClass: NavParamsStup },
         { provide: CommonProvider, useClass: CommonProviderStub },
         { provide: EventsProvider, useClass: EventsProviderStub },
         { provide: CategoriesProvider, useClass: CategoriesProviderStub }

--- a/src/pages/event-create/event-create.ts
+++ b/src/pages/event-create/event-create.ts
@@ -1,15 +1,15 @@
 import { Component } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { EventDetailPage } from './../event-detail/event-detail';
+import { EventDetailPage } from '../event-detail/event-detail';
 
 import { CommonProvider } from '../../providers/common/common';
 import { EventsProvider } from '../../providers/events/events';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
-import { DateValidators } from './../../validators/date';
+import { DateValidators } from '../../validators/date';
 
 @Component({
   selector: 'page-event-create',
@@ -21,25 +21,25 @@ export class EventCreatePage {
   public minDate: string;
   public isSubmitted = false;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private eventsProvider: EventsProvider,
-    private categoriesProvider: CategoriesProvider,
-    private datePipe: DatePipe
+  constructor(
+    private _datePipe: DatePipe,
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _commonProvider: CommonProvider,
+    private _eventsProvider: EventsProvider,
+    private _categoriesProvider: CategoriesProvider
   ) {
-    this.createForm();
+    this._createForm();
 
     const minDateObject = new Date();
     const maxDateObject = new Date();
     maxDateObject.setFullYear(maxDateObject.getFullYear() + 10);
-    this.minDate = this.datePipe.transform(minDateObject, 'yyyy-MM-dd');
-    this.maxDate = this.datePipe.transform(maxDateObject, 'yyyy-MM-dd');
+    this.minDate = this._datePipe.transform(minDateObject, 'yyyy-MM-dd');
+    this.maxDate = this._datePipe.transform(maxDateObject, 'yyyy-MM-dd');
   }
 
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -68,23 +68,25 @@ export class EventCreatePage {
 
   public createEvent() {
     this.isSubmitted = true;
-    this.eventsProvider.createEvent(this.form.value).then(
+    this._eventsProvider.createEvent(this.form.value).then(
       data => {
-        this.navCtrl.push(EventDetailPage, {'event': data});
+        this._navCtrl.push(EventDetailPage, {'event': data});
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: ['', [Validators.required]],
       category: ['', [Validators.required]],
       startDate: ['', [Validators.required, DateValidators.pastDate]],

--- a/src/pages/event-detail/event-detail.html
+++ b/src/pages/event-detail/event-detail.html
@@ -18,12 +18,10 @@
   <ion-item>
     <ion-icon name="time" item-start large></ion-icon>
     <p>
-      Starts on {{ event.startDate | date:'yyyy.MM.dd' }}
-      at {{ event.startDate | date:'HH:mm' }}
+      Starts on {{ event.startDate | date:'yyyy.MM.dd' }} at {{ event.startDate | date:'HH:mm' }}
     </p>
     <p>
-      Ends on {{ event.endDate | date:'yyyy.MM.dd' }}
-      at {{ event.endDate | date:'HH:mm' }}
+      Ends on {{ event.endDate | date:'yyyy.MM.dd' }} at {{ event.endDate | date:'HH:mm' }}
     </p>
   </ion-item>
 
@@ -32,7 +30,7 @@
   </ion-item>
 
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToEventUpdatePage()">
+    <button ion-fab (click)="navigateToUpdatePage()">
       <ion-icon name="md-create"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/event-detail/event-detail.ts
+++ b/src/pages/event-detail/event-detail.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { EventUpdatePage } from '../event-update/event-update';
 import { Event } from '../../models/event';
+
+import { EventUpdatePage } from '../event-update/event-update';
 
 @Component({
   selector: 'page-event-detail',
@@ -11,12 +12,15 @@ import { Event } from '../../models/event';
 export class EventDetailPage {
   public event: Event;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-    this.event = this.navParams.get('event');
+  constructor(
+    private _navCtrl: NavController,
+    private _navParams: NavParams
+  ) {
+    this.event = this._navParams.get('event');
   }
 
-  public navigateToEventUpdatePage() {
-    this.navCtrl.push(EventUpdatePage, { event: this.event });
+  public navigateToUpdatePage() {
+    this._navCtrl.push(EventUpdatePage, { event: this.event });
   }
 
 }

--- a/src/pages/event-list/event-list.html
+++ b/src/pages/event-list/event-list.html
@@ -3,7 +3,7 @@
 </ion-header>
 
 <ion-content padding>
-  <ion-card *ngFor="let event of events" (click)="navigateToDetail(event)">
+  <ion-card *ngFor="let event of events" (click)="navigateToDetailPage(event)">
     <ion-item>
       <ion-icon name="md-calendar" item-start large></ion-icon>
       <h2> {{ event.name }}</h2>
@@ -11,13 +11,12 @@
     </ion-item>
     <ion-item>
       <span item-left>
-        {{ event.startDate | date:'yyyy.MM.dd HH:mm' }} -
-        {{ event.endDate | date:'yyyy.MM.dd HH:mm' }}
+        {{ event.startDate | date:'yyyy.MM.dd HH:mm' }} - {{ event.endDate | date:'yyyy.MM.dd HH:mm' }}
       </span>
     </ion-item>
   </ion-card>
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToEventCreatePage()">
+    <button ion-fab (click)="navigateToCreatePage()">
       <ion-icon name="add"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/event-list/event-list.ts
+++ b/src/pages/event-list/event-list.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { EventsProvider } from './../../providers/events/events';
+import { Event } from '../../models/event';
+
 import { EventDetailPage } from '../event-detail/event-detail';
 import { EventCreatePage } from '../event-create/event-create';
-import { Event } from '../../models/event';
+
+import { EventsProvider } from '../../providers/events/events';
 
 @Component({
   selector: 'page-event-list',
@@ -12,23 +14,23 @@ import { Event } from '../../models/event';
 })
 export class EventListPage {
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private eventsProvider: EventsProvider) {
-
-    eventsProvider.updateEvents();
+  constructor(
+    private _navCtrl: NavController,
+    private _eventsProvider: EventsProvider
+  ) {
+    _eventsProvider.readEvents();
   }
 
-  get events() {
-    return this.eventsProvider.events.getValue();
+  public get events() {
+    return this._eventsProvider.events.getValue();
   }
 
-  public navigateToDetail(event: Event) {
-    this.navCtrl.push(EventDetailPage, { event: event });
+  public navigateToDetailPage(event: Event) {
+    this._navCtrl.push(EventDetailPage, { event: event });
   }
 
-  public navigateToEventCreatePage() {
-    this.navCtrl.push(EventCreatePage);
+  public navigateToCreatePage() {
+    this._navCtrl.push(EventCreatePage);
   }
 
 }

--- a/src/pages/event-update/event-update.html
+++ b/src/pages/event-update/event-update.html
@@ -40,11 +40,7 @@
 
       <ion-item>
         <ion-label floating>Start date</ion-label>
-        <ion-datetime
-          formControlName="startDate"
-          id="startDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="startDate" id="startDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -62,11 +58,7 @@
 
       <ion-item>
         <ion-label floating>End date</ion-label>
-        <ion-datetime
-          formControlName="endDate"
-          id="endDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="endDate" id="endDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -109,9 +101,7 @@
         </div>
       </div>
 
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Save
       </button>
     </form>

--- a/src/pages/event-update/event-update.spec.ts
+++ b/src/pages/event-update/event-update.spec.ts
@@ -4,21 +4,22 @@ import { DatePipe } from '@angular/common';
 import { FormBuilder } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { EventUpdatePage } from './event-update';
 import { Event } from '../../models/event';
+
+import { EventUpdatePage } from './event-update';
+
 import { CommonProvider } from '../../providers/common/common';
 import { EventsProvider } from '../../providers/events/events';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
-
 const date = new Date().toISOString().substr(0, 10);
 const event = {
-  'name': 'Event name',
-  'categoryUrl': 'https://example.com/api/categories/1/',
-  'startDate': date,
-  'endDate': date,
-  'location': 'Location',
-  'description': 'Description'
+  name: 'Event name',
+  categoryUrl: 'https://example.com/api/categories/1/',
+  startDate: date,
+  endDate: date,
+  location: 'Location',
+  description: 'Description'
 };
 
 class NavControllerStub {}
@@ -40,8 +41,8 @@ describe('Pages: EventUpdatePage', () => {
     TestBed.configureTestingModule({
       declarations: [EventUpdatePage],
       providers: [
-        FormBuilder,
         DatePipe,
+        FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
         { provide: NavParams, useClass: NavParamsStub },
         { provide: CommonProvider, useClass: CommonProviderStub },

--- a/src/pages/event-update/event-update.ts
+++ b/src/pages/event-update/event-update.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
 import { Event } from '../../models/event';
+
 import { CommonProvider } from '../../providers/common/common';
 import { EventsProvider } from '../../providers/events/events';
 import { CategoriesProvider } from '../../providers/categories/categories';
@@ -22,25 +23,26 @@ export class EventUpdatePage {
   public isSubmitted = false;
 
   constructor(
-    public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private eventsProvider: EventsProvider,
-    private categoriesProvider: CategoriesProvider,
-    private datePipe: DatePipe
+    private _datePipe: DatePipe,
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _navParams: NavParams,
+    private _commonProvider: CommonProvider,
+    private _eventsProvider: EventsProvider,
+    private _categoriesProvider: CategoriesProvider
   ) {
-    this.event = this.navParams.get('event');
-    this.createForm();
+    this.event = this._navParams.get('event');
+    this._createForm();
 
     const minDateObject = new Date();
     const maxDateObject = new Date();
     maxDateObject.setFullYear(maxDateObject.getFullYear() + 10);
-    this.minDate = this.datePipe.transform(minDateObject, 'yyyy-MM-dd');
-    this.maxDate = this.datePipe.transform(maxDateObject, 'yyyy-MM-dd');
+    this.minDate = this._datePipe.transform(minDateObject, 'yyyy-MM-dd');
+    this.maxDate = this._datePipe.transform(maxDateObject, 'yyyy-MM-dd');
   }
+
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -69,23 +71,25 @@ export class EventUpdatePage {
 
   public updateEvent() {
     this.isSubmitted = true;
-    this.eventsProvider.updateEvent(this.event.url, this.form.value).then(
+    this._eventsProvider.updateEvent(this.event.url, this.form.value).then(
       data => {
-        this.navCtrl.pop();
+        this._navCtrl.pop();
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: [this.event.name, [Validators.required]],
       category: [this.event.categoryUrl, [Validators.required]],
       startDate: [this.event.startDate, [Validators.required, DateValidators.pastDate]],

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -5,6 +5,7 @@
 <ion-content padding>
   The world is your oyster.
   <p>
-    If you get lost, the <a href="http://ionicframework.com/docs/v2">docs</a> will be your guide.
+    If you get lost, the
+    <a href="http://ionicframework.com/docs/v2">docs</a> will be your guide.
   </p>
 </ion-content>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
-import { NavController } from 'ionic-angular';
 
-import { CategoriesProvider } from './../../providers/categories/categories';
+import { CategoriesProvider } from '../../providers/categories/categories';
 
 @Component({
   selector: 'page-home',
@@ -9,10 +8,8 @@ import { CategoriesProvider } from './../../providers/categories/categories';
 })
 export class HomePage {
 
-  constructor(public navCtrl: NavController,
-    categoriesProvider: CategoriesProvider) {
-
-    categoriesProvider.updateCategories();
+  constructor(_categoriesProvider: CategoriesProvider) {
+    _categoriesProvider.readCategories();
   }
 
 }

--- a/src/pages/note-create/note-create.html
+++ b/src/pages/note-create/note-create.html
@@ -46,16 +46,14 @@
       </ion-item>
       <div *ngIf="(text.dirty || isSubmitted) && text.invalid" class="form-error-message">
         <div *ngIf="text.errors.required">
-            This field is required.
+          This field is required.
         </div>
         <div *ngIf="text.errors.remote">
           {{ text.errors.remote }}
         </div>
       </div>
 
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Create
       </button>
     </form>

--- a/src/pages/note-create/note-create.spec.ts
+++ b/src/pages/note-create/note-create.spec.ts
@@ -1,15 +1,15 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { NoteCreatePage } from './note-create';
+
 import { CommonProvider } from '../../providers/common/common';
 import { NotesProvider } from '../../providers/notes/notes';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
 class NavControllerStub {}
-class NavParamsStup {}
 class CommonProviderStub {}
 class NotesProviderStub {}
 class CategoriesProviderStub {}
@@ -25,7 +25,6 @@ describe('Pages: NoteCreatePage', () => {
       providers: [
         FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
-        { provide: NavParams, useClass: NavParamsStup },
         { provide: CommonProvider, useClass: CommonProviderStub },
         { provide: NotesProvider, useClass: NotesProviderStub },
         { provide: CategoriesProvider, useClass: CategoriesProviderStub }

--- a/src/pages/note-create/note-create.ts
+++ b/src/pages/note-create/note-create.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { NoteDetailPage } from './../note-detail/note-detail';
+import { NoteDetailPage } from '../note-detail/note-detail';
 
 import { CommonProvider } from '../../providers/common/common';
 import { NotesProvider } from '../../providers/notes/notes';
@@ -14,22 +14,20 @@ import { CategoriesProvider } from '../../providers/categories/categories';
 })
 export class NoteCreatePage {
   public form: FormGroup;
-  public maxDate: string;
-  public minDate: string;
   public isSubmitted = false;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private notesProvider: NotesProvider,
-    private categoriesProvider: CategoriesProvider,
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _commonProvider: CommonProvider,
+    private _notesProvider: NotesProvider,
+    private _categoriesProvider: CategoriesProvider,
   ) {
-    this.createForm();
+    this._createForm();
   }
 
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -46,23 +44,25 @@ export class NoteCreatePage {
 
   public createNote() {
     this.isSubmitted = true;
-    this.notesProvider.createNote(this.form.value).then(
+    this._notesProvider.createNote(this.form.value).then(
       data => {
-        this.navCtrl.push(NoteDetailPage, {'note': data});
+        this._navCtrl.push(NoteDetailPage, {'note': data});
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: ['', [Validators.required]],
       category: ['', [Validators.required]],
       text: ['', [Validators.required]],

--- a/src/pages/note-detail/note-detail.html
+++ b/src/pages/note-detail/note-detail.html
@@ -15,7 +15,7 @@
   </ion-item>
 
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToNoteUpdatePage()">
+    <button ion-fab (click)="navigateToUpdatePage()">
       <ion-icon name="md-create"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/note-detail/note-detail.ts
+++ b/src/pages/note-detail/note-detail.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { NoteUpdatePage } from '../note-update/note-update';
 import { Note } from '../../models/note';
+
+import { NoteUpdatePage } from '../note-update/note-update';
 
 @Component({
   selector: 'page-note-detail',
@@ -11,12 +12,15 @@ import { Note } from '../../models/note';
 export class NoteDetailPage {
   public note: Note;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-    this.note = this.navParams.get('note');
+  constructor(
+    private _navCtrl: NavController,
+    private _navParams: NavParams
+  ) {
+    this.note = this._navParams.get('note');
   }
 
-  public navigateToNoteUpdatePage() {
-    this.navCtrl.push(NoteUpdatePage, { note: this.note });
+  public navigateToUpdatePage() {
+    this._navCtrl.push(NoteUpdatePage, { note: this.note });
   }
 
 }

--- a/src/pages/note-list/note-list.html
+++ b/src/pages/note-list/note-list.html
@@ -3,7 +3,7 @@
 </ion-header>
 
 <ion-content padding>
-  <ion-card *ngFor="let note of notes" (click)="navigateToDetail(note)">
+  <ion-card *ngFor="let note of notes" (click)="navigateToDetailPage(note)">
     <ion-item>
       <ion-icon name="md-calendar" item-start large></ion-icon>
       <h2> {{ note.name }}</h2>
@@ -11,7 +11,7 @@
     </ion-item>
   </ion-card>
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToNoteCreatePage()">
+    <button ion-fab (click)="navigateToCreatePage()">
       <ion-icon name="add"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/note-list/note-list.ts
+++ b/src/pages/note-list/note-list.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { NotesProvider } from './../../providers/notes/notes';
-import { NoteDetailPage } from './../note-detail/note-detail';
-import { NoteCreatePage } from './../note-create/note-create';
 import { Note } from '../../models/note';
+
+import { NoteDetailPage } from '../note-detail/note-detail';
+import { NoteCreatePage } from '../note-create/note-create';
+
+import { NotesProvider } from '../../providers/notes/notes';
 
 @Component({
   selector: 'page-note-list',
@@ -12,23 +14,23 @@ import { Note } from '../../models/note';
 })
 export class NoteListPage {
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private notesProvider: NotesProvider) {
-
-    notesProvider.updateNotes();
+  constructor(
+    private _navCtrl: NavController,
+    private _notesProvider: NotesProvider
+  ) {
+    _notesProvider.readNotes();
   }
 
-  get notes() {
-    return this.notesProvider.notes.getValue();
+  public get notes() {
+    return this._notesProvider.notes.getValue();
   }
 
-  public navigateToDetail(note: Note) {
-    this.navCtrl.push(NoteDetailPage, { note: note });
+  public navigateToDetailPage(note: Note) {
+    this._navCtrl.push(NoteDetailPage, { note: note });
   }
 
-  public navigateToNoteCreatePage() {
-    this.navCtrl.push(NoteCreatePage);
+  public navigateToCreatePage() {
+    this._navCtrl.push(NoteCreatePage);
   }
 
 }

--- a/src/pages/note-update/note-update.html
+++ b/src/pages/note-update/note-update.html
@@ -1,5 +1,5 @@
 <ion-header>
-  <header pageTitle="Create note"></header>
+  <header pageTitle="Change note"></header>
 </ion-header>
 
 <ion-content padding>
@@ -46,16 +46,14 @@
       </ion-item>
       <div *ngIf="(text.dirty || isSubmitted) && text.invalid" class="form-error-message">
         <div *ngIf="text.errors.required">
-            This field is required.
+          This field is required.
         </div>
         <div *ngIf="text.errors.remote">
           {{ text.errors.remote }}
         </div>
       </div>
 
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Save
       </button>
     </form>

--- a/src/pages/note-update/note-update.spec.ts
+++ b/src/pages/note-update/note-update.spec.ts
@@ -3,18 +3,19 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { NoteUpdatePage } from './note-update';
 import { Note } from '../../models/note';
+
+import { NoteUpdatePage } from './note-update';
+
 import { CommonProvider } from '../../providers/common/common';
 import { NotesProvider } from '../../providers/notes/notes';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
-
 const date = new Date().toISOString().substr(0, 10);
 const note = {
-  'name': 'Note name',
-  'categoryUrl': 'https://example.com/api/categories/1/',
-  'text': 'Note text'
+  name: 'Note name',
+  categoryUrl: 'https://example.com/api/categories/1/',
+  text: 'Note text'
 };
 
 class NavControllerStub {}

--- a/src/pages/note-update/note-update.ts
+++ b/src/pages/note-update/note-update.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
 import { Note } from '../../models/note';
+
 import { CommonProvider } from '../../providers/common/common';
 import { NotesProvider } from '../../providers/notes/notes';
 import { CategoriesProvider } from '../../providers/categories/categories';
@@ -16,19 +17,20 @@ export class NoteUpdatePage {
   public form: FormGroup;
   public isSubmitted = false;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private notesProvider: NotesProvider,
-    private categoriesProvider: CategoriesProvider,
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _navParams: NavParams,
+    private _commonProvider: CommonProvider,
+    private _notesProvider: NotesProvider,
+    private _categoriesProvider: CategoriesProvider,
   ) {
-    this.note = this.navParams.get('note');
-    this.createForm();
+    this.note = this._navParams.get('note');
+    this._createForm();
   }
 
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -45,23 +47,25 @@ export class NoteUpdatePage {
 
   public updateNote() {
     this.isSubmitted = true;
-    this.notesProvider.updateNote(this.note.url, this.form.value).then(
+    this._notesProvider.updateNote(this.note.url, this.form.value).then(
       data => {
-        this.navCtrl.pop();
+        this._navCtrl.pop();
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: [this.note.name, [Validators.required]],
       category: [this.note.categoryUrl, [Validators.required]],
       text: [this.note.text, [Validators.required]],

--- a/src/pages/sign-in/sign-in.html
+++ b/src/pages/sign-in/sign-in.html
@@ -7,16 +7,14 @@
     <form [formGroup]="form" (ngSubmit)="signIn()">
       <ion-item>
         <ion-label floating>Username</ion-label>
-        <ion-input formControlName="username"
-          id="username"
-          type="text">
+        <ion-input formControlName="username" id="username" type="text">
         </ion-input>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
 
       <div *ngIf="username.touched && username.invalid" class="form-error-message">
         <div *ngIf="username.errors.required">
-            Username is required.
+          Username is required.
         </div>
         <div *ngIf="username.errors.minlength">
           Username should be minimum {{ username.errors.minlength.requiredLength }} characters.
@@ -25,10 +23,7 @@
 
       <ion-item class="input-item">
         <ion-label floating>Password</ion-label>
-        <ion-input
-          formControlName="password"
-          id="password"
-          type="password">
+        <ion-input formControlName="password" id="password" type="password">
         </ion-input>
       </ion-item>
 

--- a/src/pages/sign-in/sign-in.spec.ts
+++ b/src/pages/sign-in/sign-in.spec.ts
@@ -1,14 +1,14 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { SignInPage } from './sign-in';
-import { CommonProvider } from './../../providers/common/common';
-import { AuthProvider } from './../../providers/auth/auth';
+
+import { CommonProvider } from '../../providers/common/common';
+import { AuthProvider } from '../../providers/auth/auth';
 
 class NavControllerStub {}
-class NavParamsStup {}
 class CommonProviderStub {}
 class AuthProviderStub {}
 
@@ -23,7 +23,6 @@ describe('Pages: SignInPage', () => {
       providers: [
         FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
-        { provide: NavParams, useClass: NavParamsStup },
         { provide: CommonProvider, useClass: CommonProviderStub },
         { provide: AuthProvider, useClass: AuthProviderStub }
       ],
@@ -45,8 +44,8 @@ describe('Pages: SignInPage', () => {
     updateForm('test_username', 'test_password');
     expect(component.form.valid).toBeTruthy();
     expect(component.form.value).toEqual({
-      'username': 'test_username',
-      'password': 'test_password'
+      username: 'test_username',
+      password: 'test_password'
     });
   });
 

--- a/src/pages/sign-in/sign-in.ts
+++ b/src/pages/sign-in/sign-in.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { HomePage } from '../home/home';
 
-import { CommonProvider } from './../../providers/common/common';
-import { AuthProvider } from './../../providers/auth/auth';
+import { CommonProvider } from '../../providers/common/common';
+import { AuthProvider } from '../../providers/auth/auth';
 
 @Component({
   selector: 'page-sign-in',
@@ -14,13 +14,13 @@ import { AuthProvider } from './../../providers/auth/auth';
 export class SignInPage {
   public form: FormGroup;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private authProvider: AuthProvider) {
-
-    this.form = this.formBuilder.group({
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _commonProvider: CommonProvider,
+    private _authProvider: AuthProvider
+  ) {
+    this.form = this._formBuilder.group({
       username: ['', [Validators.required, Validators.minLength(4)]],
       password: ['', [Validators.required, Validators.minLength(4)]],
     });
@@ -37,15 +37,17 @@ export class SignInPage {
   public signIn() {
     const username: string = this.form.value.username;
     const password: string = this.form.value.password;
-    this.authProvider.signIn(username, password).subscribe(
+    this._authProvider.signIn(username, password).subscribe(
       data => {
-        this.commonProvider.setAuthenticationData(data);
-        this.navCtrl.setRoot(HomePage);
+        this._commonProvider.setAuthenticationData(data);
+        this._navCtrl.setRoot(HomePage);
       },
       error => {
         for (const key in error.error) {
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }

--- a/src/pages/sign-up/sign-up.spec.ts
+++ b/src/pages/sign-up/sign-up.spec.ts
@@ -1,14 +1,14 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { SignUpPage } from './sign-up';
-import { CommonProvider } from './../../providers/common/common';
-import { AuthProvider } from './../../providers/auth/auth';
+
+import { CommonProvider } from '../../providers/common/common';
+import { AuthProvider } from '../../providers/auth/auth';
 
 class NavControllerStub {}
-class NavParamsStup {}
 class CommonProviderStub {}
 class AuthProviderStub {}
 
@@ -23,7 +23,6 @@ describe('Pages: SignUpPage', () => {
       providers: [
         FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
-        { provide: NavParams, useClass: NavParamsStup },
         { provide: CommonProvider, useClass: CommonProviderStub },
         { provide: AuthProvider, useClass: AuthProviderStub }
       ],
@@ -48,11 +47,11 @@ describe('Pages: SignUpPage', () => {
     updateForm('john.doe', 'doe.john', 'john.doe@example.com', 'John', 'Doe');
     expect(component.form.valid).toBeTruthy();
     expect(component.form.value).toEqual({
-      'username': 'john.doe',
-      'password': 'doe.john',
-      'email': 'john.doe@example.com',
-      'firstName': 'John',
-      'lastName': 'Doe'
+      username: 'john.doe',
+      password: 'doe.john',
+      email: 'john.doe@example.com',
+      firstName: 'John',
+      lastName: 'Doe'
     });
   });
 

--- a/src/pages/sign-up/sign-up.ts
+++ b/src/pages/sign-up/sign-up.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { SignInPage } from '../sign-in/sign-in';
 
-import { CommonProvider } from './../../providers/common/common';
-import { AuthProvider } from './../../providers/auth/auth';
+import { CommonProvider } from '../../providers/common/common';
+import { AuthProvider } from '../../providers/auth/auth';
 
 @Component({
   selector: 'page-sign-up',
@@ -14,13 +14,13 @@ import { AuthProvider } from './../../providers/auth/auth';
 export class SignUpPage {
   public form: FormGroup;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private authProvider: AuthProvider) {
-
-    this.form = this.formBuilder.group({
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _commonProvider: CommonProvider,
+    private _authProvider: AuthProvider
+  ) {
+    this.form = this._formBuilder.group({
       username: ['', [Validators.required, Validators.minLength(4)]],
       email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(4)]],
@@ -50,15 +50,17 @@ export class SignUpPage {
   }
 
   public signUp() {
-    this.authProvider.signUp(this.form.value).subscribe(
+    this._authProvider.signUp(this.form.value).subscribe(
       data => {
-        this.navCtrl.setRoot(SignInPage);
+        this._navCtrl.setRoot(SignInPage);
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }

--- a/src/pages/task-create/task-create.html
+++ b/src/pages/task-create/task-create.html
@@ -40,11 +40,7 @@
 
       <ion-item>
         <ion-label floating>Start date</ion-label>
-        <ion-datetime
-          formControlName="startDate"
-          id="startDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="startDate" id="startDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -62,11 +58,7 @@
 
       <ion-item>
         <ion-label floating>End date</ion-label>
-        <ion-datetime
-          formControlName="endDate"
-          id="endDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="endDate" id="endDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -115,9 +107,7 @@
         </div>
       </div>
 
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Create
       </button>
     </form>

--- a/src/pages/task-create/task-create.spec.ts
+++ b/src/pages/task-create/task-create.spec.ts
@@ -2,15 +2,15 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe } from '@angular/common';
 import { FormBuilder } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import { TaskCreatePage } from './task-create';
+
 import { CommonProvider } from '../../providers/common/common';
 import { TasksProvider } from '../../providers/tasks/tasks';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
 class NavControllerStub {}
-class NavParamsStup {}
 class CommonProviderStub {}
 class TasksProviderStub {}
 class CategoriesProviderStub {}
@@ -24,10 +24,9 @@ describe('Pages: TaskCreatePage', () => {
     TestBed.configureTestingModule({
       declarations: [TaskCreatePage],
       providers: [
-        FormBuilder,
         DatePipe,
+        FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
-        { provide: NavParams, useClass: NavParamsStup },
         { provide: CommonProvider, useClass: CommonProviderStub },
         { provide: TasksProvider, useClass: TasksProviderStub },
         { provide: CategoriesProvider, useClass: CategoriesProviderStub }

--- a/src/pages/task-create/task-create.ts
+++ b/src/pages/task-create/task-create.ts
@@ -1,15 +1,15 @@
 import { Component } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { TaskDetailPage } from './../task-detail/task-detail';
+import { TaskDetailPage } from '../task-detail/task-detail';
 
 import { CommonProvider } from '../../providers/common/common';
 import { TasksProvider } from '../../providers/tasks/tasks';
 import { CategoriesProvider } from '../../providers/categories/categories';
 
-import { DateValidators } from './../../validators/date';
+import { DateValidators } from '../../validators/date';
 
 @Component({
   selector: 'page-task-create',
@@ -21,33 +21,29 @@ export class TaskCreatePage {
   public minDate: string;
   public isSubmitted = false;
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private tasksProvider: TasksProvider,
-    private categoriesProvider: CategoriesProvider,
-    private datePipe: DatePipe
+  constructor(
+    private _datePipe: DatePipe,
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _commonProvider: CommonProvider,
+    private _tasksProvider: TasksProvider,
+    private _categoriesProvider: CategoriesProvider
   ) {
-    this.createForm();
+    this._createForm();
 
     const minDateObject = new Date();
     const maxDateObject = new Date();
     maxDateObject.setFullYear(maxDateObject.getFullYear() + 10);
-    this.minDate = this.datePipe.transform(minDateObject, 'yyyy-MM-dd');
-    this.maxDate = this.datePipe.transform(maxDateObject, 'yyyy-MM-dd');
-  }
-
-  public get statusOptions() {
-    return this.tasksProvider.statusOptions;
+    this.minDate = this._datePipe.transform(minDateObject, 'yyyy-MM-dd');
+    this.maxDate = this._datePipe.transform(maxDateObject, 'yyyy-MM-dd');
   }
 
   public get priorityOptions() {
-    return this.tasksProvider.priorityOptions;
+    return this._tasksProvider.priorityOptions;
   }
 
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -80,13 +76,13 @@ export class TaskCreatePage {
 
   public createTask() {
     this.isSubmitted = true;
-    this.tasksProvider.createTask(this.form.value).then(
+    this._tasksProvider.createTask(this.form.value).then(
       data => {
-        this.navCtrl.push(TaskDetailPage, {'task': data});
+        this._navCtrl.push(TaskDetailPage, {'task': data});
       },
       error => {
         for (const key in error.error) {
-          const formKey = this.commonProvider.toCamelCase(key);
+          const formKey = this._commonProvider.toCamelCase(key);
           if (this.form.get(formKey)) {
             this.form.get(formKey).setErrors({remote: error.error[key]});
           }
@@ -95,8 +91,8 @@ export class TaskCreatePage {
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: ['', [Validators.required]],
       category: ['', [Validators.required]],
       startDate: ['', [DateValidators.pastDate]],

--- a/src/pages/task-detail/task-detail.html
+++ b/src/pages/task-detail/task-detail.html
@@ -19,12 +19,10 @@
   <ion-item>
     <ion-icon name="time" item-start large></ion-icon>
     <p>
-      Date: {{ task.startDate | date:'yyyy.MM.dd' }}
-      at {{ task.startDate | date:'HH:mm' }}
+      Date: {{ task.startDate | date:'yyyy.MM.dd' }} at {{ task.startDate | date:'HH:mm' }}
     </p>
     <p>
-      Due date: {{ task.endDate | date:'yyyy.MM.dd' }}
-      at {{ task.endDate | date:'HH:mm' }}
+      Due date: {{ task.endDate | date:'yyyy.MM.dd' }} at {{ task.endDate | date:'HH:mm' }}
     </p>
   </ion-item>
 
@@ -33,7 +31,7 @@
   </ion-item>
 
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToTaskUpdatePage()">
+    <button ion-fab (click)="navigateToUpdatePage()">
       <ion-icon name="md-create"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/task-detail/task-detail.ts
+++ b/src/pages/task-detail/task-detail.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { TaskUpdatePage } from '../task-update/task-update';
 import { Task } from '../../models/task';
+
+import { TaskUpdatePage } from '../task-update/task-update';
 
 @Component({
   selector: 'page-task-detail',
@@ -11,13 +12,15 @@ import { Task } from '../../models/task';
 export class TaskDetailPage {
   public task: Task;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-    this.task = this.navParams.get('task');
+  constructor(
+    private _navCtrl: NavController,
+    private _navParams: NavParams
+  ) {
+    this.task = this._navParams.get('task');
   }
 
-  public navigateToTaskUpdatePage() {
-    this.navCtrl.push(TaskUpdatePage, { task: this.task });
+  public navigateToUpdatePage() {
+    this._navCtrl.push(TaskUpdatePage, { task: this.task });
   }
-
 
 }

--- a/src/pages/task-list/task-list.html
+++ b/src/pages/task-list/task-list.html
@@ -3,7 +3,7 @@
 </ion-header>
 
 <ion-content padding>
-  <ion-card *ngFor="let task of tasks" (click)="navigateToDetail(task)">
+  <ion-card *ngFor="let task of tasks" (click)="navigateToDetailPage(task)">
     <ion-item>
       <ion-icon name="md-calendar" item-start large></ion-icon>
       <h2> {{ task.name }}</h2>
@@ -11,13 +11,12 @@
     </ion-item>
     <ion-item>
       <span item-left>
-        {{ task.startDate | date:'yyyy.MM.dd HH:mm' }} -
-        {{ task.endDate | date:'yyyy.MM.dd HH:mm' }}
+        {{ task.startDate | date:'yyyy.MM.dd HH:mm' }} - {{ task.endDate | date:'yyyy.MM.dd HH:mm' }}
       </span>
     </ion-item>
   </ion-card>
   <ion-fab right bottom>
-    <button ion-fab (click)="navigateToTaskCreatePage()">
+    <button ion-fab (click)="navigateToCreatePage()">
       <ion-icon name="add"></ion-icon>
     </button>
   </ion-fab>

--- a/src/pages/task-list/task-list.ts
+++ b/src/pages/task-list/task-list.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
-import { TasksProvider } from './../../providers/tasks/tasks';
+import { Task } from '../../models/task';
+
 import { TaskDetailPage } from '../task-detail/task-detail';
 import { TaskCreatePage } from '../task-create/task-create';
-import { Task } from '../../models/task';
+
+import { TasksProvider } from '../../providers/tasks/tasks';
 
 @Component({
   selector: 'page-task-list',
@@ -12,23 +14,23 @@ import { Task } from '../../models/task';
 })
 export class TaskListPage {
 
-  constructor(public navCtrl: NavController,
-    public navParams: NavParams,
-    private tasksProvider: TasksProvider) {
+  constructor(
+    private _navCtrl: NavController,
+    private _tasksProvider: TasksProvider
+  ) {
+    _tasksProvider.readTasks();
 
-      tasksProvider.updateTasks();
-    }
-
-    get tasks() {
-      return this.tasksProvider.tasks.getValue();
-    }
-
-  public navigateToDetail(task: Task) {
-    this.navCtrl.push(TaskDetailPage, { task: task });
+  }
+  public get tasks() {
+    return this._tasksProvider.tasks.getValue();
   }
 
-  public navigateToTaskCreatePage() {
-    this.navCtrl.push(TaskCreatePage);
+  public navigateToDetailPage(task: Task) {
+    this._navCtrl.push(TaskDetailPage, { task: task });
+  }
+
+  public navigateToCreatePage() {
+    this._navCtrl.push(TaskCreatePage);
   }
 
 }

--- a/src/pages/task-update/task-update.html
+++ b/src/pages/task-update/task-update.html
@@ -40,11 +40,7 @@
 
       <ion-item>
         <ion-label floating>Start date</ion-label>
-        <ion-datetime
-          formControlName="startDate"
-          id="startDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="startDate" id="startDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -62,11 +58,7 @@
 
       <ion-item>
         <ion-label floating>End date</ion-label>
-        <ion-datetime
-          formControlName="endDate"
-          id="endDate"
-          [min]="minDate"
-          [max]="maxDate">
+        <ion-datetime formControlName="endDate" id="endDate" [min]="minDate" [max]="maxDate">
         </ion-datetime>
         <i class="icon ion-alert-circled error"></i>
       </ion-item>
@@ -115,9 +107,7 @@
         </div>
       </div>
 
-      <button ion-button block type="submit"
-        class="submit-button"
-        [disabled]="!form.valid">
+      <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Save
       </button>
     </form>

--- a/src/pages/task-update/task-update.spec.ts
+++ b/src/pages/task-update/task-update.spec.ts
@@ -4,12 +4,13 @@ import { DatePipe } from '@angular/common';
 import { FormBuilder } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
-import { TaskUpdatePage } from './task-update';
 import { Task } from '../../models/task';
+
+import { TaskUpdatePage } from './task-update';
+
 import { CommonProvider } from '../../providers/common/common';
 import { TasksProvider } from '../../providers/tasks/tasks';
 import { CategoriesProvider } from '../../providers/categories/categories';
-
 
 const date = new Date().toISOString().substr(0, 10);
 const task = {
@@ -40,8 +41,8 @@ describe('Pages: TaskUpdatePage', () => {
     TestBed.configureTestingModule({
       declarations: [TaskUpdatePage],
       providers: [
-        FormBuilder,
         DatePipe,
+        FormBuilder,
         { provide: NavController, useClass: NavControllerStub },
         { provide: NavParams, useClass: NavParamsStub },
         { provide: CommonProvider, useClass: CommonProviderStub },

--- a/src/pages/task-update/task-update.ts
+++ b/src/pages/task-update/task-update.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 
 import { Task } from '../../models/task';
+
 import { CommonProvider } from '../../providers/common/common';
 import { TasksProvider } from '../../providers/tasks/tasks';
 import { CategoriesProvider } from '../../providers/categories/categories';
@@ -22,30 +23,30 @@ export class TaskUpdatePage {
   public isSubmitted = false;
 
   constructor(
-    public navCtrl: NavController,
-    public navParams: NavParams,
-    private formBuilder: FormBuilder,
-    private commonProvider: CommonProvider,
-    private tasksProvider: TasksProvider,
-    private categoriesProvider: CategoriesProvider,
-    private datePipe: DatePipe
+    private _datePipe: DatePipe,
+    private _formBuilder: FormBuilder,
+    private _navCtrl: NavController,
+    private _navParams: NavParams,
+    private _commonProvider: CommonProvider,
+    private _tasksProvider: TasksProvider,
+    private _categoriesProvider: CategoriesProvider
   ) {
-    this.task = this.navParams.get('task');
-    this.createForm();
+    this.task = this._navParams.get('task');
+    this._createForm();
 
     const minDateObject = new Date();
     const maxDateObject = new Date();
     maxDateObject.setFullYear(maxDateObject.getFullYear() + 10);
-    this.minDate = this.datePipe.transform(minDateObject, 'yyyy-MM-dd');
-    this.maxDate = this.datePipe.transform(maxDateObject, 'yyyy-MM-dd');
+    this.minDate = this._datePipe.transform(minDateObject, 'yyyy-MM-dd');
+    this.maxDate = this._datePipe.transform(maxDateObject, 'yyyy-MM-dd');
   }
 
   public get priorityOptions() {
-    return this.tasksProvider.priorityOptions;
+    return this._tasksProvider.priorityOptions;
   }
 
   public get categories() {
-    return this.categoriesProvider.categories.getValue();
+    return this._categoriesProvider.categories.getValue();
   }
 
   public get name() {
@@ -74,23 +75,25 @@ export class TaskUpdatePage {
 
   public updateTask() {
     this.isSubmitted = true;
-    this.tasksProvider.updateTask(this.task.url, this.form.value).then(
+    this._tasksProvider.updateTask(this.task.url, this.form.value).then(
       data => {
-        this.navCtrl.pop();
+        this._navCtrl.pop();
       },
       error => {
         for (let key in error.error) {
-          key = this.commonProvider.toCamelCase(key);
+          key = this._commonProvider.toCamelCase(key);
           if (this.form.get(key)) {
-            this.form.get(key).setErrors({remote: error.error[key]});
+            this.form.get(key).setErrors({
+              remote: error.error[key]
+            });
           }
         }
       }
     );
   }
 
-  private createForm() {
-    this.form = this.formBuilder.group({
+  private _createForm() {
+    this.form = this._formBuilder.group({
       name: [this.task.name, [Validators.required]],
       category: [this.task.categoryUrl, [Validators.required]],
       startDate: [this.task.startDate, [Validators.required, DateValidators.pastDate]],

--- a/src/providers/auth/auth.ts
+++ b/src/providers/auth/auth.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 
-import { CommonProvider } from './../common/common';
+import { CommonProvider } from '../common/common';
 import { ENV } from '@app/env';
 
 @Injectable()
 export class AuthProvider {
   private _env = ENV;
 
-  constructor(private commonProvider: CommonProvider) {
+  constructor(private _commonProvider: CommonProvider) {
   }
 
   public signUp(data) {
@@ -18,7 +18,7 @@ export class AuthProvider {
       'first_name': data.firstName,
       'last_name': data.lastName
     };
-    return this.commonProvider.performRequest('users/', 'POST', request_data);
+    return this._commonProvider.performRequest('users/', 'POST', request_data);
   }
 
   public signIn(username, password) {
@@ -29,7 +29,7 @@ export class AuthProvider {
       'username': username,
       'password': password
     };
-    return this.commonProvider.performRequest('oauth2/token/', 'POST', data);
+    return this._commonProvider.performRequest('oauth2/token/', 'POST', data);
   }
 
   public refreshToken() {
@@ -37,9 +37,9 @@ export class AuthProvider {
       'grant_type': 'refresh_token',
       'client_id': this._env.clientID,
       'client_secret': this._env.clientSecret,
-      'refresh_token': this.commonProvider.refreshToken
+      'refresh_token': this._commonProvider.refreshToken
     };
-    return this.commonProvider.performRequest('oauth2/token/', 'POST', data);
+    return this._commonProvider.performRequest('oauth2/token/', 'POST', data);
   }
 
 }

--- a/src/providers/categories/categories.spec.ts
+++ b/src/providers/categories/categories.spec.ts
@@ -3,33 +3,33 @@ import { HttpParams } from '@angular/common/http';
 
 import { Observable } from 'rxjs/Observable';
 
-import { CommonProvider } from './../common/common';
+import { CommonProvider } from '../common/common';
 import { CategoriesProvider } from './categories';
-import { Category } from './../../models/category';
+import { Category } from '../../models/category';
 
 const getCategoriesResponse = {
   'results': [
     {
-      'url': 'https://example.com/api/categories/1/',
-      'name': 'Category name',
-      'author': 'https://example.com/api/authors/1/',
-      'events': ['https://example.com/api/tasks/1/'],
-      'notes': ['https://example.com/api/notes/1/'],
-      'tasks': ['https://example.com/api/tasks/1/'],
-      'description': 'Description',
-      'created_at': '2018-04-01T06:23:05.288858Z',
-      'updated_at': '2018-04-01T06:23:05.288906Z',
+      url: 'https://example.com/api/categories/1/',
+      name: 'Category name',
+      author: 'https://example.com/api/authors/1/',
+      events: ['https://example.com/api/tasks/1/'],
+      notes: ['https://example.com/api/notes/1/'],
+      tasks: ['https://example.com/api/tasks/1/'],
+      description: 'Description',
+      created_at: '2018-04-01T06:23:05.288858Z',
+      updated_at: '2018-04-01T06:23:05.288906Z',
     },
     {
-      'url': 'https://example.com/api/categories/2/',
-      'name': 'Category name 2',
-      'author': 'https://example.com/api/authors/2/',
-      'events': ['https://example.com/api/tasks/1/'],
-      'notes': ['https://example.com/api/notes/2/'],
-      'tasks': ['https://example.com/api/tasks/2/'],
-      'description': 'Description 2',
-      'created_at': '2018-04-01T06:23:05.288858Z',
-      'updated_at': '2018-04-01T06:23:05.288906Z',
+      url: 'https://example.com/api/categories/2/',
+      name: 'Category name 2',
+      author: 'https://example.com/api/authors/2/',
+      events: ['https://example.com/api/tasks/1/'],
+      notes: ['https://example.com/api/notes/2/'],
+      tasks: ['https://example.com/api/tasks/2/'],
+      description: 'Description 2',
+      created_at: '2018-04-01T06:23:05.288858Z',
+      updated_at: '2018-04-01T06:23:05.288906Z',
     }
   ]
 };
@@ -53,14 +53,14 @@ describe('Providers: CategoriesProvider', () => {
     ]
   }));
 
-  beforeEach(inject([CategoriesProvider], categoriesProvider => {
-    provider = categoriesProvider;
+  beforeEach(inject([CategoriesProvider], _categoriesProvider => {
+    provider = _categoriesProvider;
   }));
 
 
   it('Should update categories', (done) => {
 
-    provider.updateCategories().then(
+    provider.readCategories().then(
       data => {
         const categories = provider.categories.getValue();
         expect(categories.length).toBe(getCategoriesResponse.results.length);

--- a/src/providers/categories/categories.ts
+++ b/src/providers/categories/categories.ts
@@ -3,23 +3,23 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { JsonConvert } from 'json2typescript';
 
-import { CommonProvider } from './../common/common';
-import { Category } from './../../models/category';
+import { CommonProvider } from '../common/common';
+import { Category } from '../../models/category';
 
 @Injectable()
 export class CategoriesProvider {
   private _categories = new BehaviorSubject<Array<Category>>([]);
 
-  constructor(private commonProvider: CommonProvider) {
+  constructor(private _commonProvider: CommonProvider) {
   }
 
-  get categories() {
+  public get categories() {
     return this._categories;
   }
 
-  public updateCategories(): Promise<boolean> {
+  public readCategories(): Promise<boolean> {
     return new Promise ((resolve, reject) => {
-      this.getCategories().subscribe(
+      this._commonProvider.performRequest('categories/', 'GET').subscribe(
         (data: any) => {
           const jsonConvert: JsonConvert = new JsonConvert();
           this._categories.next(jsonConvert.deserializeArray(data.results, Category));
@@ -30,10 +30,6 @@ export class CategoriesProvider {
         }
       );
     });
-  }
-
-  private getCategories() {
-    return this.commonProvider.performRequest('categories/', 'GET');
   }
 
 }

--- a/src/providers/common/common.ts
+++ b/src/providers/common/common.ts
@@ -11,15 +11,16 @@ export class CommonProvider {
   private _refreshToken: string;
   private _scope: string;
 
-  constructor(public http: HttpClient,
-    private storage: Storage) {
-  }
+  constructor(
+    public http: HttpClient,
+    private _storage: Storage
+  ) {}
 
-  get isAuthenticated() {
+  public get isAuthenticated() {
      return this._accessToken ? true : false;
   }
 
-  get refreshToken() {
+  public get refreshToken() {
     return this._refreshToken;
   }
 
@@ -28,17 +29,17 @@ export class CommonProvider {
     this._refreshToken = data.refresh_token;
     this._scope = data.scope;
 
-    const storageObject = {
+    const _storageObject = {
       'accessToken': data.access_token,
       'refreshToken': data.refresh_token
     };
-    this.storage.set('authenticationData', storageObject);
+    this._storage.set('authenticationData', _storageObject);
   }
 
   public readAuthenticationData(): Promise<boolean> {
     return new Promise (resolve => {
-      this.storage.ready().then(() => {
-        this.storage.get('authenticationData').then((authenticationData) => {
+      this._storage.ready().then(() => {
+        this._storage.get('authenticationData').then((authenticationData) => {
           if (authenticationData) {
             this._accessToken = authenticationData.accessToken;
             this._refreshToken = authenticationData.refreshToken;
@@ -59,7 +60,7 @@ export class CommonProvider {
       url = `${this._env.apiUrl}/${url}`;
     }
     const data = JSON.stringify(requestData);
-    const headers = this.getHeaders(requestMethod);
+    const headers = this._getHeaders(requestMethod);
     const options = {
       headers: headers
     };
@@ -87,7 +88,7 @@ export class CommonProvider {
     });
   }
 
-  private getHeaders(requestMethod: string) {
+  private _getHeaders(requestMethod: string) {
     let headers: HttpHeaders = new HttpHeaders();
 
     headers = headers.append('Content-Type', 'application/json');
@@ -98,4 +99,5 @@ export class CommonProvider {
 
     return headers;
   }
+
 }

--- a/src/providers/events/events.spec.ts
+++ b/src/providers/events/events.spec.ts
@@ -4,38 +4,38 @@ import { HttpParams } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 import { Observable } from 'rxjs/Observable';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
 import { EventsProvider } from './events';
 
-import { Category } from './../../models/category';
-import { Event } from './../../models/event';
+import { Category } from '../../models/category';
+import { Event } from '../../models/event';
 
 const getEventsResponse = {
-  'results': [
+  results: [
     {
-      'url': 'https://example.com/api/events/1/',
-      'name': 'Event name',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/1/',
-      'start_date': '2018-04-02T01:00:00Z',
-      'end_date': '2018-04-20T01:00:00Z',
-      'created_at': '2018-04-01T06:23:05.288858Z',
-      'updated_at': '2018-04-01T06:23:05.288906Z',
-      'location': 'Location',
-      'description': 'Description'
+      url: 'https://example.com/api/events/1/',
+      name: 'Event name',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/1/',
+      start_date: '2018-04-02T01:00:00Z',
+      end_date: '2018-04-20T01:00:00Z',
+      created_at: '2018-04-01T06:23:05.288858Z',
+      updated_at: '2018-04-01T06:23:05.288906Z',
+      location: 'Location',
+      description: 'Description'
     },
     {
-      'url': 'https://example.com/api/events/2/',
-      'name': 'Event name 2',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/2/',
-      'start_date': '2018-04-02T04:00:00Z',
-      'end_date': '2018-04-20T04:00:00Z',
-      'created_at': '2018-04-01T06:26:01.288858Z',
-      'updated_at': '2018-04-01T06:26:01.288858Z',
-      'location': 'Location',
-      'description': 'Description'
+      url: 'https://example.com/api/events/2/',
+      name: 'Event name 2',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/2/',
+      start_date: '2018-04-02T04:00:00Z',
+      end_date: '2018-04-20T04:00:00Z',
+      created_at: '2018-04-01T06:26:01.288858Z',
+      updated_at: '2018-04-01T06:26:01.288858Z',
+      location: 'Location',
+      description: 'Description'
     }
   ]
 };
@@ -51,12 +51,12 @@ class CommonProviderStub {
 
 class CategoriesProviderStub {
 
-  get categories() {
-    const categoryList: Array<Category> = [this.createCategory(1), this.createCategory(2)];
+  public get categories() {
+    const categoryList: Array<Category> = [this._createCategory(1), this._createCategory(2)];
     return new BehaviorSubject<Array<Category>>(categoryList);
   }
 
-  private createCategory(id) {
+  private _createCategory(id) {
     const category = new Category();
     category.url = `https://example.com/api/categories/${id}/`;
     category.name = `Category ${id}`;
@@ -75,14 +75,14 @@ describe('Providers: EventsProvider', () => {
     ]
   }));
 
-  beforeEach(inject([EventsProvider], eventsProvider => {
-    provider = eventsProvider;
+  beforeEach(inject([EventsProvider], _eventsProvider => {
+    provider = _eventsProvider;
   }));
 
 
   it('Should update events', (done) => {
 
-    provider.updateEvents().then(
+    provider.readEvents().then(
       data => {
         const events = provider.events.getValue();
         expect(events.length).toBe(getEventsResponse.results.length);

--- a/src/providers/events/events.ts
+++ b/src/providers/events/events.ts
@@ -3,73 +3,31 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { JsonConvert } from 'json2typescript';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
-import { Event } from './../../models/event';
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
+import { Event } from '../../models/event';
 
 @Injectable()
 export class EventsProvider {
   private _events = new BehaviorSubject<Array<Event>>([]);
 
-  constructor(private commonProvider: CommonProvider,
-    private categoriesProvider: CategoriesProvider) {
-  }
+  constructor(
+    private _commonProvider: CommonProvider,
+    private _categoriesProvider: CategoriesProvider
+  ) {}
 
-  get events() {
+  public get events() {
     return this._events;
   }
 
-  public updateEvent(url: string, data: any) {
+  public readEvents(): Promise<boolean> {
     return new Promise ((resolve, reject) => {
-      data.start_date = new Date(data.startDate);
-      data.end_date = new Date(data.endDate);
-      this.commonProvider.performRequest(url, 'PUT', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const event: Event = jsonConvert.deserialize(data, Event);
-          const events: Array<Event> = this._events.getValue();
-          const index = events.findIndex(x => x.url === url);
-
-          this.setCategory(event);
-          events[index] = Object.assign(events[index], event);
-
-          resolve(event);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public createEvent(data: any) {
-    return new Promise ((resolve, reject) => {
-      data.start_date = new Date(data.startDate);
-      data.end_date = new Date(data.endDate);
-      this.commonProvider.performRequest('events/', 'POST', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const event: Event = jsonConvert.deserialize(data, Event);
-          const events: Array<Event> = this._events.getValue();
-          this.setCategory(event);
-          events.push(event);
-          resolve(event);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public updateEvents(): Promise<boolean> {
-    return new Promise ((resolve, reject) => {
-      this.getEvents().subscribe(
+      this._commonProvider.performRequest('events/', 'GET').subscribe(
         (data: any) => {
           const jsonConvert: JsonConvert = new JsonConvert();
           const events: Array<Event> = jsonConvert.deserializeArray(data.results, Event);
           for (const event of events) {
-            this.setCategory(event);
+            this._setCategory(event);
           }
           this._events.next(events);
           resolve();
@@ -81,13 +39,53 @@ export class EventsProvider {
     });
   }
 
-  private getEvents() {
-    return this.commonProvider.performRequest('events/', 'GET');
+  public createEvent(data: any) {
+    return new Promise ((resolve, reject) => {
+      data.start_date = new Date(data.startDate);
+      data.end_date = new Date(data.endDate);
+      this._commonProvider.performRequest('events/', 'POST', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const event: Event = jsonConvert.deserialize(data, Event);
+          const events: Array<Event> = this._events.getValue();
+          this._setCategory(event);
+          events.push(event);
+          resolve(event);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
 
-  private setCategory(event) {
-    event.category = this.categoriesProvider.categories.getValue().filter(
-      category => category.url === event.categoryUrl
-    )[0];
+  public updateEvent(url: string, data: any) {
+    return new Promise ((resolve, reject) => {
+      data.start_date = new Date(data.startDate);
+      data.end_date = new Date(data.endDate);
+      this._commonProvider.performRequest(url, 'PUT', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const event: Event = jsonConvert.deserialize(data, Event);
+          const events: Array<Event> = this._events.getValue();
+          const index = events.findIndex(x => x.url === url);
+
+          this._setCategory(event);
+          events[index] = Object.assign(events[index], event);
+
+          resolve(event);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
+
+  private _setCategory(event) {
+    event.category = this._categoriesProvider.categories.getValue().find(
+      category => category.url === event.categoryUrl
+    );
+  }
+
 }

--- a/src/providers/notes/notes.spec.ts
+++ b/src/providers/notes/notes.spec.ts
@@ -4,32 +4,32 @@ import { HttpParams } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 import { Observable } from 'rxjs/Observable';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
 import { NotesProvider } from './notes';
 
-import { Category } from './../../models/category';
-import { Note } from './../../models/note';
+import { Category } from '../../models/category';
+import { Note } from '../../models/note';
 
 const getNotesResponse = {
   'results': [
     {
-      'url': 'https://example.com/api/notes/1/',
-      'name': 'Note name',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/1/',
-      'created_at': '2018-04-01T06:23:05.288858Z',
-      'updated_at': '2018-04-01T06:23:05.288906Z',
-      'text': 'Text',
+      url: 'https://example.com/api/notes/1/',
+      name: 'Note name',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/1/',
+      created_at: '2018-04-01T06:23:05.288858Z',
+      updated_at: '2018-04-01T06:23:05.288906Z',
+      text: 'Text',
     },
     {
-      'url': 'https://example.com/api/notes/2/',
-      'name': 'Note name 2',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/2/',
-      'created_at': '2018-04-01T06:26:01.288858Z',
-      'updated_at': '2018-04-01T06:26:01.288858Z',
-      'text': 'Text 2'
+      url: 'https://example.com/api/notes/2/',
+      name: 'Note name 2',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/2/',
+      created_at: '2018-04-01T06:26:01.288858Z',
+      updated_at: '2018-04-01T06:26:01.288858Z',
+      text: 'Text 2'
     }
   ]
 };
@@ -45,12 +45,12 @@ class CommonProviderStub {
 
 class CategoriesProviderStub {
 
-  get categories() {
-    const categoryList: Array<Category> = [this.createCategory(1), this.createCategory(2)];
+  public get categories() {
+    const categoryList: Array<Category> = [this._createCategory(1), this._createCategory(2)];
     return new BehaviorSubject<Array<Category>>(categoryList);
   }
 
-  private createCategory(id) {
+  private _createCategory(id) {
     const category = new Category();
     category.url = `https://example.com/api/categories/${id}/`;
     category.name = `Category ${id}`;
@@ -69,14 +69,14 @@ describe('Providers: NotesProvider', () => {
     ]
   }));
 
-  beforeEach(inject([NotesProvider], notesProvider => {
-    provider = notesProvider;
+  beforeEach(inject([NotesProvider], _notesProvider => {
+    provider = _notesProvider;
   }));
 
 
   it('Should update notes', (done) => {
 
-    provider.updateNotes().then(
+    provider.readNotes().then(
       data => {
         const notes = provider.notes.getValue();
         expect(notes.length).toBe(getNotesResponse.results.length);

--- a/src/providers/notes/notes.ts
+++ b/src/providers/notes/notes.ts
@@ -3,73 +3,32 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { JsonConvert } from 'json2typescript';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
-import { Note } from './../../models/note';
-
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
+import { Note } from '../../models/note';
 
 @Injectable()
 export class NotesProvider {
   private _notes = new BehaviorSubject<Array<Note>>([]);
 
-  constructor(private commonProvider: CommonProvider,
-    private categoriesProvider: CategoriesProvider) {
-  }
+  constructor(
+    private _commonProvider: CommonProvider,
+    private _categoriesProvider: CategoriesProvider
+  ) {}
 
-  get notes() {
+  public get notes() {
     return this._notes;
   }
 
-  public updateNote(url: string, data: any) {
+  public readNotes(): Promise<boolean> {
     return new Promise ((resolve, reject) => {
-      data.start_date = new Date(data.startDate);
-      data.end_date = new Date(data.endDate);
-      this.commonProvider.performRequest(url, 'PUT', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const note: Note = jsonConvert.deserialize(data, Note);
-          const notes: Array<Note> = this._notes.getValue();
-          const index = notes.findIndex(x => x.url === url);
-
-          this.setCategory(note);
-          notes[index] = Object.assign(notes[index], note);
-
-          resolve(note);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public createNote(data: any) {
-    return new Promise ((resolve, reject) => {
-      this.commonProvider.performRequest('notes/', 'POST', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const note: Note = jsonConvert.deserialize(data, Note);
-          const notes: Array<Note> = this._notes.getValue();
-          this.setCategory(note);
-          notes.push(note);
-          resolve(note);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public updateNotes(): Promise<boolean> {
-    return new Promise ((resolve, reject) => {
-      this.getNotes().subscribe(
+      this._commonProvider.performRequest('notes/', 'GET').subscribe(
         (data: any) => {
           const jsonConvert: JsonConvert = new JsonConvert();
 
           const notes: Array<Note> = jsonConvert.deserializeArray(data.results, Note);
           for (const note of notes) {
-            this.setCategory(note);
+            this._setCategory(note);
           }
           this._notes.next(notes);
 
@@ -82,13 +41,51 @@ export class NotesProvider {
     });
   }
 
-  private getNotes() {
-    return this.commonProvider.performRequest('notes/', 'GET');
+  public createNote(data: any) {
+    return new Promise ((resolve, reject) => {
+      this._commonProvider.performRequest('notes/', 'POST', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const note: Note = jsonConvert.deserialize(data, Note);
+          const notes: Array<Note> = this._notes.getValue();
+          this._setCategory(note);
+          notes.push(note);
+          resolve(note);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
 
-  private setCategory(note) {
-    note.category = this.categoriesProvider.categories.getValue().filter(
-      category => category.url === note.categoryUrl
-    )[0];
+  public updateNote(url: string, data: any) {
+    return new Promise ((resolve, reject) => {
+      data.start_date = new Date(data.startDate);
+      data.end_date = new Date(data.endDate);
+      this._commonProvider.performRequest(url, 'PUT', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const note: Note = jsonConvert.deserialize(data, Note);
+          const notes: Array<Note> = this._notes.getValue();
+          const index = notes.findIndex(x => x.url === url);
+
+          this._setCategory(note);
+          notes[index] = Object.assign(notes[index], note);
+
+          resolve(note);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
+
+  private _setCategory(note) {
+    note.category = this._categoriesProvider.categories.getValue().find(
+      category => category.url === note.categoryUrl
+    );
+  }
+
 }

--- a/src/providers/tasks/tasks.spec.ts
+++ b/src/providers/tasks/tasks.spec.ts
@@ -4,42 +4,42 @@ import { HttpParams } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 import { Observable } from 'rxjs/Observable';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
 import { TasksProvider } from './tasks';
 
-import { Category } from './../../models/category';
-import { Task } from './../../models/task';
+import { Category } from '../../models/category';
+import { Task } from '../../models/task';
 
 const getTasksResponse = {
   'results': [
     {
-      'url': 'https://example.com/api/tasks/1/',
-      'name': 'Task name',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/1/',
-      'parent': '',
-      'start_date': '2018-04-02T01:00:00Z',
-      'end_date': '2018-04-20T01:00:00Z',
-      'created_at': '2018-04-01T06:23:05.288858Z',
-      'updated_at': '2018-04-01T06:23:05.288906Z',
-      'status': 'Status',
-      'priority': 'Priority',
-      'description': 'Description'
+      url: 'https://example.com/api/tasks/1/',
+      name: 'Task name',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/1/',
+      parent: '',
+      start_date: '2018-04-02T01:00:00Z',
+      end_date: '2018-04-20T01:00:00Z',
+      created_at: '2018-04-01T06:23:05.288858Z',
+      updated_at: '2018-04-01T06:23:05.288906Z',
+      status: 'Status',
+      priority: 'Priority',
+      description: 'Description'
     },
     {
-      'url': 'https://example.com/api/tasks/2/',
-      'name': 'Task name 2',
-      'author': 'https://example.com/api/authors/1/',
-      'category': 'https://example.com/api/categories/2/',
-      'parent': 'https://example.com/api/tasks/1/',
-      'start_date': '2018-04-02T04:00:00Z',
-      'end_date': '2018-04-20T04:00:00Z',
-      'created_at': '2018-04-01T06:26:01.288858Z',
-      'updated_at': '2018-04-01T06:26:01.288858Z',
-      'status': 'Status',
-      'priority': 'Priority',
-      'description': 'Description'
+      url: 'https://example.com/api/tasks/2/',
+      name: 'Task name 2',
+      author: 'https://example.com/api/authors/1/',
+      category: 'https://example.com/api/categories/2/',
+      parent: 'https://example.com/api/tasks/1/',
+      start_date: '2018-04-02T04:00:00Z',
+      end_date: '2018-04-20T04:00:00Z',
+      created_at: '2018-04-01T06:26:01.288858Z',
+      updated_at: '2018-04-01T06:26:01.288858Z',
+      status: 'Status',
+      priority: 'Priority',
+      description: 'Description'
     }
   ]
 };
@@ -55,12 +55,12 @@ class CommonProviderStub {
 
 class CategoriesProviderStub {
 
-  get categories() {
-    const categoryList: Array<Category> = [this.createCategory(1), this.createCategory(2)];
+  public get categories() {
+    const categoryList: Array<Category> = [this._createCategory(1), this._createCategory(2)];
     return new BehaviorSubject<Array<Category>>(categoryList);
   }
 
-  private createCategory(id) {
+  private _createCategory(id) {
     const category = new Category();
     category.url = `https://example.com/api/categories/${id}/`;
     category.name = `Category ${id}`;
@@ -80,14 +80,14 @@ describe('Providers: TasksProvider', () => {
     ]
   }));
 
-  beforeEach(inject([TasksProvider], tasksProvider => {
-    provider = tasksProvider;
+  beforeEach(inject([TasksProvider], _tasksProvider => {
+    provider = _tasksProvider;
   }));
 
 
   it('Should update tasks', (done) => {
 
-    provider.updateTasks().then(
+    provider.readTasks().then(
       data => {
         const tasks = provider.tasks.getValue();
         expect(tasks.length).toBe(getTasksResponse.results.length);

--- a/src/providers/tasks/tasks.ts
+++ b/src/providers/tasks/tasks.ts
@@ -3,9 +3,9 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { JsonConvert } from 'json2typescript';
 
-import { CommonProvider } from './../common/common';
-import { CategoriesProvider } from './../categories/categories';
-import { Task } from './../../models/task';
+import { CommonProvider } from '../common/common';
+import { CategoriesProvider } from '../categories/categories';
+import { Task } from '../../models/task';
 
 @Injectable()
 export class TasksProvider {
@@ -20,65 +20,23 @@ export class TasksProvider {
   ];
   private _tasks = new BehaviorSubject<Array<Task>>([]);
 
-  constructor(private commonProvider: CommonProvider,
-    private categoriesProvider: CategoriesProvider) {
-  }
+  constructor(
+    private _commonProvider: CommonProvider,
+    private _categoriesProvider: CategoriesProvider
+  ) {}
 
-  get tasks() {
+  public get tasks() {
     return this._tasks;
   }
 
-  public updateTask(url: string, data: any) {
+  public readTasks(): Promise<boolean> {
     return new Promise ((resolve, reject) => {
-      data.start_date = new Date(data.startDate);
-      data.end_date = new Date(data.endDate);
-      this.commonProvider.performRequest(url, 'PUT', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const task: Task = jsonConvert.deserialize(data, Task);
-          const tasks: Array<Task> = this._tasks.getValue();
-          const index = tasks.findIndex(x => x.url === url);
-
-          this.setCategory(task);
-          tasks[index] = Object.assign(tasks[index], task);
-
-          resolve(task);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public createTask(data: any) {
-    return new Promise ((resolve, reject) => {
-      data.start_date = new Date(data.startDate);
-      data.end_date = new Date(data.endDate);
-      this.commonProvider.performRequest('tasks/', 'POST', data).subscribe(
-        (data: any) => {
-          const jsonConvert: JsonConvert = new JsonConvert();
-          const task: Task = jsonConvert.deserialize(data, Task);
-          const tasks: Array<Task> = this._tasks.getValue();
-          this.setCategory(task);
-          tasks.push(task);
-          resolve(task);
-        },
-        error => {
-          reject(error);
-        }
-      );
-    });
-  }
-
-  public updateTasks(): Promise<boolean> {
-    return new Promise ((resolve, reject) => {
-      this.getTasks().subscribe(
+      this._commonProvider.performRequest('tasks/', 'GET').subscribe(
         (data: any) => {
           const jsonConvert: JsonConvert = new JsonConvert();
           const tasks: Array<Task> = jsonConvert.deserializeArray(data.results, Task);
           for (const task of tasks) {
-            this.setCategory(task);
+            this._setCategory(task);
           }
           this._tasks.next(tasks);
           resolve();
@@ -90,13 +48,53 @@ export class TasksProvider {
     });
   }
 
-  private getTasks() {
-    return this.commonProvider.performRequest('tasks/', 'GET');
+  public createTask(data: any) {
+    return new Promise ((resolve, reject) => {
+      data.start_date = new Date(data.startDate);
+      data.end_date = new Date(data.endDate);
+      this._commonProvider.performRequest('tasks/', 'POST', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const task: Task = jsonConvert.deserialize(data, Task);
+          const tasks: Array<Task> = this._tasks.getValue();
+          this._setCategory(task);
+          tasks.push(task);
+          resolve(task);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
 
-  private setCategory(task) {
-    task.category = this.categoriesProvider.categories.getValue().filter(
-      category => category.url === task.categoryUrl
-    )[0];
+  public updateTask(url: string, data: any) {
+    return new Promise ((resolve, reject) => {
+      data.start_date = new Date(data.startDate);
+      data.end_date = new Date(data.endDate);
+      this._commonProvider.performRequest(url, 'PUT', data).subscribe(
+        (data: any) => {
+          const jsonConvert: JsonConvert = new JsonConvert();
+          const task: Task = jsonConvert.deserialize(data, Task);
+          const tasks: Array<Task> = this._tasks.getValue();
+          const index = tasks.findIndex(x => x.url === url);
+
+          this._setCategory(task);
+          tasks[index] = Object.assign(tasks[index], task);
+
+          resolve(task);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
+
+  private _setCategory(task) {
+    task.category = this._categoriesProvider.categories.getValue().find(
+      category => category.url === task.categoryUrl
+    );
+  }
+
 }


### PR DESCRIPTION
- HTML attributes are moved on the same line until line length exceeds 120 characters.
- `Array.find` is used instead of `Array.filter` wherever possible.
- Each parameter in constructors with multiple parameters is on a separate line.
- All private methods and properties are prefixed with `_`.
- Changed import order and paths.
- Minor indentation changes and typo fixes.
- Changed order of methods in providers.