### PR TITLE
Remove debug elements from `EventCreatePage`

### DIFF
--- a/src/pages/event-create/event-create.html
+++ b/src/pages/event-create/event-create.html
@@ -100,7 +100,7 @@
           {{ description.errors.remote }}
         </div>
       </div>
-      <input type="text" class="test-calss-gegwegwegweg" id="tetetet-tettet" data-test="tgetwetwet" name="tetetette">
+
       <button ion-button block type="submit" class="submit-button" [disabled]="!form.valid">
         Create
       </button>


### PR DESCRIPTION
This element was added to test how the editor will split HTML attributes when the specified line length is exceeded and was somehow missed during the code review.